### PR TITLE
Only apply section italics to title, not the expand icon

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -42,7 +42,7 @@ img {
 }
 
 
-li.chapter-item div {
+li.chapter-item > div {
   font-style: italic;
   color: rgb(200, 201, 219);
 }


### PR DESCRIPTION
Sorry, I just had to fix this. It was driving me crazy every time I looked at the manual :sweat_smile: 

## Before
![image](https://github.com/user-attachments/assets/8e03cf6c-1716-436a-a829-92594759ee5b)


## After
![image](https://github.com/user-attachments/assets/9529c064-3336-4716-b7fc-053fac7477ad)
