### PR TITLE
Update dictionaries.md to include Faroese samples

### DIFF
--- a/src/usage/languages/dictionaries.md
+++ b/src/usage/languages/dictionaries.md
@@ -295,6 +295,7 @@ Below are the dictionaries for the languages that come pre-configured with Lute:
 |Icelandic|terms|embedded|`https://is.wiktionary.org/wiki/[LUTE]#%C3%8Dslenska`|
 |Icelandic|terms|embedded|`https://www.verbix.com/webverbix/go.php?&D1=1028&T1=[LUTE]`|
 |Icelandic|terms|embedded|`https://www.verbix.com/webverbix/go.php?&D1=28&T1=[LUTE]`|
+|Icelandic|terms|popup|`https://malid.is/leit/[LUTE]`|
 |Icelandic|terms|popup|`https://tatoeba.org/en/sentences/search?from=isl&query=[LUTE]&to=eng`|
 |Indonesian|sentences|popup|`https://www.deepl.com/translator#id/en/[LUTE]`|
 |Indonesian|terms|embedded|`https://en.wiktionary.org/wiki/[LUTE]#Indonesian`|

--- a/src/usage/languages/dictionaries.md
+++ b/src/usage/languages/dictionaries.md
@@ -179,6 +179,16 @@ Below are the dictionaries for the languages that come pre-configured with Lute:
 |Estonian|terms|embedded|`https://www.verbix.com/webverbix/go.php?&D1=4178&T1=[LUTE]`|
 |Estonian|terms|popup|`https://en.glosbe.com/et/en/[LUTE]`|
 |Estonian|terms|popup|`https://tatoeba.org/en/sentences/search?from=est&query=[LUTE]&to=eng`|
+|Faroese|sentences|embedded|`https://www.bing.com/translator/?from=fo&to=en&text=[LUTE]`|
+|Faroese|sentences|popup|`https://translate.google.com/?sl=fo&tl=en&text=[LUTE]&op=translate&hl=en`|
+|Faroese|terms|embedded|`https://cooljugator.com/fo/[LUTE]`|
+|Faroese|terms|embedded|`https://en.glosbe.com/fo/en/[LUTE]`|
+|Faroese|terms|embedded|`https://en.wiktionary.org/wiki/[LUTE]#Faroese`|
+|Faroese|terms|embedded|`https://is.wiktionary.org/wiki/hvar#F%C3%A6reyska`|
+|Faroese|terms|embedded|`https://www.verbix.com/webverbix/go.php?&D1=1075&T1=[LUTE]`|
+|Faroese|terms|embedded|`https://www.verbix.com/webverbix/go.php?&D1=75&T1=[LUTE]`|
+|Faroese|terms|popup|`https://tatoeba.org/en/sentences/search?from=fao&query=[LUTE]&to=eng`|
+|Faroese|terms|popup|`https://sprotin.fo/dictionaries?_SearchInflections=0&_SearchDescriptions=0&_DictionaryId=1&_DictionaryPage=1&_SearchFor=[LUTE]`
 |Farsi|sentences|popup|`https://translate.google.com/?sl=fa&tl=en&text=[LUTE]&op=translate`|
 |Farsi|terms|embedded|`https://dsal.uchicago.edu/cgi-bin/app/persian_query.py?qs=[LUTE]&searchhws=yes&matchtype=default`|
 |Farsi|terms|embedded|`https://en.wiktionary.org/wiki/[LUTE]#Persian`|

--- a/src/usage/languages/dictionaries.md
+++ b/src/usage/languages/dictionaries.md
@@ -188,7 +188,7 @@ Below are the dictionaries for the languages that come pre-configured with Lute:
 |Faroese|terms|embedded|`https://www.verbix.com/webverbix/go.php?&D1=1075&T1=[LUTE]`|
 |Faroese|terms|embedded|`https://www.verbix.com/webverbix/go.php?&D1=75&T1=[LUTE]`|
 |Faroese|terms|popup|`https://tatoeba.org/en/sentences/search?from=fao&query=[LUTE]&to=eng`|
-|Faroese|terms|popup|`https://sprotin.fo/dictionaries?_SearchInflections=0&_SearchDescriptions=0&_DictionaryId=1&_DictionaryPage=1&_SearchFor=[LUTE]`
+|Faroese|terms|popup|`https://sprotin.fo/dictionaries?_SearchInflections=0&_SearchDescriptions=0&_DictionaryId=1&_DictionaryPage=1&_SearchFor=[LUTE]`|
 |Farsi|sentences|popup|`https://translate.google.com/?sl=fa&tl=en&text=[LUTE]&op=translate`|
 |Farsi|terms|embedded|`https://dsal.uchicago.edu/cgi-bin/app/persian_query.py?qs=[LUTE]&searchhws=yes&matchtype=default`|
 |Farsi|terms|embedded|`https://en.wiktionary.org/wiki/[LUTE]#Persian`|


### PR DESCRIPTION
Added one Icelandic dictionary that offers translations into other Scandinavian languages and Faroese dictionaries to the `dictionaries.md` table. Two unique entries while others are just the same as for Icelandic with the language code changed.