### PR TITLE
src: uniform usage of "Lute" instead of "LUTE"

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -1,6 +1,6 @@
 # Introduction
 
-LUTE (Learning Using Texts) is a standalone web application that you install on your computer and read texts with.
+Lute (Learning Using Texts) is a standalone web application that you install on your computer and read texts with.
 
 Lute contains the core features you need for learning through reading:
 


### PR DESCRIPTION
As mentioned in https://github.com/LuteOrg/lute-v3/issues/624
Changes "LUTE" to "Lute".

There seemed to be only one occurrence in the docs besides the `[LUTE] `Parameters in the examples. 